### PR TITLE
홈화면 챌린지 리스트 이미지 기본이미지 조회 불가 수정

### DIFF
--- a/fourweeks/src/main/webapp/WEB-INF/views/chal/list.jsp
+++ b/fourweeks/src/main/webapp/WEB-INF/views/chal/list.jsp
@@ -297,7 +297,14 @@ ul.pagenation > li > a:focus {
               </div>
                </c:if>
                <%-- 시작일 조건 --%>
-               <c:if test="${chalDto.getDDay() > 0}">
+               <c:if test="${chalDto.getDDay() == 1}">
+               <div class="row chal-item">
+                 <img src="${pageContext.request.contextPath}/images/chal_start_date.png" class="img-margin">
+                          내일 시작
+              </div>
+               </c:if>
+               <%-- 시작일 조건 --%>
+               <c:if test="${chalDto.getDDay() > 1}">
                <div class="row chal-item">
                  <img src="${pageContext.request.contextPath}/images/chal_start_date.png" class="img-margin">
                           ${chalDto.getDDay()}일 뒤 시작
@@ -396,7 +403,7 @@ ul.pagenation > li > a:focus {
             <div class="row chal-list">   
                <div class="row chal-item thumbnail">
                <%-- 이미지 --%>
-                  <img class="main-img" src="detail/download?chalNo=${chalDto.getChalNo()}">
+                  <img class="main-img" src="detail/download?chalNo=${chalDto.getChalNo()}" onerror=" this.onerror=null; this.src='/images/bg_default.png';" >
                
                </div>
                <div class="row chal-item">

--- a/fourweeks/src/main/webapp/WEB-INF/views/chalUser/mypage.jsp
+++ b/fourweeks/src/main/webapp/WEB-INF/views/chalUser/mypage.jsp
@@ -142,6 +142,16 @@ padding: 14px 138px;
 margin-left: 10px;
 cursor:pointer;
 }
+.btn1no{
+font-size:16px;
+font-weight: 700;
+border: 2px solid  #DDDDDD;
+border-radius: 0.5em;
+background-color: #DDDDDD;
+color:  #AAAAAA;
+padding: 14px 138px;
+pointer-events: none;
+}
 .btn1:disabled{
 font-size:16px;
 font-weight: 700;
@@ -485,7 +495,7 @@ header.header-fixed {
       
 <c:otherwise>
  <div class="row row-3"> 
-   <a class="btn1" href ="${pageContext.request.contextPath}/confirm/write">챌린지 인증</a>
+   <a class="btn1no" href ="${pageContext.request.contextPath}/confirm/write" >챌린지 인증</a>
    <a class="btn2" href ="${pageContext.request.contextPath}/chal/create"> 챌린지 개설</a>
 </div>
    <c:forEach var="chalEndDto" items="${chalEndDto}">

--- a/fourweeks/src/main/webapp/WEB-INF/views/home.jsp
+++ b/fourweeks/src/main/webapp/WEB-INF/views/home.jsp
@@ -253,7 +253,7 @@
 			 	<div class="row chal-item thumbnail">
 					<%-- 이미지 --%>
 					
-						<img class="main-img" src="chal/detail/download?chalNo=${chalDto.getChalNo()}">
+						<img class="main-img" src="detail/download?chalNo=${chalDto.getChalNo()}" onerror=" this.onerror=null; this.src='/images/bg_default.png';" >
 					
 		         </div>
 		         <div class="row chal-item">
@@ -273,7 +273,14 @@
 			     </div>
 		         </c:if>
 		         <%-- 시작일 조건 --%>
-		         <c:if test="${chalDto.getDDay() > 0}">
+		         <c:if test="${chalDto.getDDay() == 1}">
+		         <div class="row chal-item">
+			        <img src="/images/chal_start_date.png" class="img-margin">
+			                 내일 시작
+			     </div>
+		         </c:if>
+		         <%-- 시작일 조건 --%>
+		         <c:if test="${chalDto.getDDay() > 1}">
 		         <div class="row chal-item">
 			        <img src="/images/chal_start_date.png" class="img-margin">
 			                 ${chalDto.getDDay()}일 뒤 시작


### PR DESCRIPTION
챌린지 리스트 전체 탭 조회시 이미지 조회 불가 수정
챌린지 목록 (1일뒤시작 -> 오늘시작) 라벨수정
챌린지 개설시 대표이미지 설정후 개설시 오류발생 수정
헤더 로고 클릭시 현재페이지 머뭄 현상(home으로 안가짐)(이거 서버에서는 잘됨 local에서만 안되는것임)
챌린지 개설시 대표이미지 설정후 개설시 오류발생(이거 서버에서는 잘됨 local에서만 안되는것임)